### PR TITLE
Remove out of context usage of `.data`

### DIFF
--- a/R/make_choose_all_table.R
+++ b/R/make_choose_all_table.R
@@ -53,7 +53,7 @@ make_choose_all_table <- function(df, variable) {
     }) %>%
     tibble::enframe(name = NULL) %>%  # new variable is value
     dplyr::rename("What" = .data$value) %>% 
-    dplyr::bind_cols(.data$., counts) %>% 
+    dplyr::bind_cols(counts) %>% 
     dplyr::select(.data$What, .data$Count)
   aTable
 }


### PR DESCRIPTION
Hello, I see in revdep checks for rlang 1.0.0:

```
  --- re-building ‘makeChooseAllTable.Rmd’ using rmarkdown
  Quitting from lines 56-57 (makeChooseAllTable.Rmd) 
  Error: processing vignette ‘makeChooseAllTable.Rmd’ failed with diagnostics:
  Can't subset `.data` outside of a data mask context.
```

This error indicates that `.data` wasn't used properly. We now detect these cases early to prevent coding mistakes from being unnoticed. In this case, `.data` was used in `bind_cols()` which is not a data-masking function.