### PR TITLE
fix: resolve CRAN test failures and improve API error handling

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^doc$
 ^Meta$
 ^.github/
+^.claude/
+^CLAUDE.md$

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Meta
 docs/
 inst/docs/
 
+# AI
+.claude/
+CLAUDE.md

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,10 +7,12 @@
 ## New features
 
 * `drop_label()` now can be used on data frames. When called without arguments on a data frame, it removes labels from all variables.
+* `import_instruments()` now provides clearer error messages when REDCap API calls fail, helping users diagnose API URL, token permission, or network connectivity issues.
 
 ## Fixes/Changes
 
 * `drop_labels()` is now deprecated in favor of `drop_label()`. Use `drop_label()` without arguments to remove labels from all variables.
+* Fixed CRAN test failures on Linux/Windows platforms by making `import_instruments()` tests skip gracefully when external REDCap API is not accessible. Tests now check API availability before running and skip automatically when the API cannot be reached.
 
 # tidyREDCap 1.2.0
 

--- a/R/import_instruments.R
+++ b/R/import_instruments.R
@@ -41,12 +41,32 @@ import_instruments <- function(url, token, drop_blank = TRUE,
                                envir = .GlobalEnv) {
   cli::cli_inform("Reading metadata about your project.... ")
 
-  ds_instrument <-
+  metadata_result <-
     suppressWarnings(
       suppressMessages(
-        REDCapR::redcap_metadata_read(redcap_uri = url, token = token)$data
+        REDCapR::redcap_metadata_read(redcap_uri = url, token = token)
       )
     )
+
+  if (!metadata_result$success || nrow(metadata_result$data) == 0) {
+    error_parts <- c(
+      "Failed to read project metadata from REDCap API.",
+      i = "Please check:",
+      i = "  - Your API URL is correct",
+      i = "  - Your API token has proper permissions",
+      i = "  - Your network can reach the REDCap server"
+    )
+    if (!is.null(metadata_result$status_message) &&
+          nzchar(metadata_result$status_message)) {
+      error_parts <- c(
+        error_parts,
+        i = paste("API response:", metadata_result$status_message)
+      )
+    }
+    rlang::abort(error_parts)
+  }
+
+  ds_instrument <- metadata_result$data
 
   # Get names of instruments
   form_name <- NULL

--- a/tests/testthat/test-import_instruments.R
+++ b/tests/testthat/test-import_instruments.R
@@ -1,9 +1,22 @@
-# Tests for the import_instruments against the import from data returned by 
+# Tests for the import_instruments against the import from data returned by
 #   REDCapR
-# Ray Balise and Gabriel Odom 
+# Ray Balise and Gabriel Odom
 # 2023-02-10
 
 library(testthat)
+
+######  API Availability Check  ######
+api_available <- tryCatch({
+  suppressWarnings(
+    suppressMessages({
+      result <- REDCapR::redcap_metadata_read(
+        redcap_uri = "https://bbmc.ouhsc.edu/redcap/api/",
+        token = "9A81268476645C4E5F03428B8AC3AA7B"
+      )
+      result$success && nrow(result$data) > 0
+    })
+  )
+}, error = function(e) FALSE)
 
 ######  Setup  ######
 target <- structure(
@@ -80,16 +93,20 @@ target <- structure(
   row.names = c(NA, -5L), class = c("tbl_df", "tbl", "data.frame")
 )
 
-# creates demographics
-tidyREDCap::import_instruments(
-  "https://bbmc.ouhsc.edu/redcap/api/",
-  "9A81268476645C4E5F03428B8AC3AA7B"
-)
+# creates demographics (only if API is available)
+if (api_available) {
+  tidyREDCap::import_instruments(
+    "https://bbmc.ouhsc.edu/redcap/api/",
+    "9A81268476645C4E5F03428B8AC3AA7B"
+  )
+}
 
 
 
 ######  Tests  ######
 test_that("import works", {
+  skip_if(!api_available, "External REDCap API not accessible")
+
   if (packageVersion("REDCapR") <= "1.1.0") {
     expect_equal(demographics, target, ignore_attr = TRUE)
   } else {


### PR DESCRIPTION
Fixes CRAN test failures on 8/14 platforms (Linux/Windows) by making import_instruments() tests resilient to external API unavailability.

Changes:
- Add API availability check before running import_instruments() tests
- Tests now skip gracefully when external REDCap API is inaccessible
- Enhanced import_instruments() with clear error messages for API failures
- Users now get actionable guidance when API calls fail (check URL, token, network)

Technical details:
- Replaced unconditional test setup with conditional check (api_available)
- Added skip_if() logic based on actual API accessibility
- Improved error handling in R/import_instruments.R with rlang::abort()
- No breaking changes to function behavior when API works correctly

Test results:
- 44 tests pass
- 1 test skips when API unavailable (expected)
- 0 failures

This addresses the CRAN check failures while maintaining test coverage when the API is accessible and improving the user experience with better error diagnostics.